### PR TITLE
Initialize Project Structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,68 @@
+# ----- OS files -----
+.DS_Store
+Thumbs.db
+ehthumbs.db
+Icon?
+._*
+.Spotlight-V100
+.Trashes
+.AppleDouble
+.LSOverride
+.fseventsd
+.TemporaryItems
+*.swp
+*.swo
+*.orig
+
+# ----- Editors / IDE -----
+.vscode/
+.idea/
+*.iml
+.history/
+*.code-workspace
+
+# ----- Node / pnpm monorepo -----
+node_modules/
+.pnpm-store/
+pnpm-debug.log*
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+package-lock.json
+yarn.lock
+dist/
+build/
+lib/
+tmp/
+temp/
+.cache/
+.eslintcache
+*.tsbuildinfo
+*.tgz
+
+# ----- Environment files -----
+# Ignore all env files, keep examples
+.env
+.env.*
+!.env.example
+!.env.*.example
+
+# ----- Tests / coverage -----
+coverage/
+.nyc_output/
+*.lcov
+
+# ----- Next.js -----
+.next/
+out/
+.vercel/
+.turbo/
+
+# ----- AWS CDK -----
+cdk.out/
+.cdk.staging/
+
+# ----- Serverless (if used later) -----
+.serverless/
+

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,11 @@
+# Web App (Next.js)
+
+This is the placeholder for the Next.js application.
+
+- Scripts are placeholders for now.
+- Add Next.js and related deps later.
+
+```bash
+pnpm --filter @collect-iq/web dev
+```
+

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@collect-iq/web",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "echo 'TODO: next dev'",
+    "build": "echo 'TODO: next build'",
+    "start": "echo 'TODO: next start'"
+  }
+}
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "collect-iq",
+  "version": "0.0.0",
+  "private": true,
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "scripts": {
+    "lint": "echo 'TODO: lint workspace'",
+    "typecheck": "echo 'TODO: typecheck workspace'"
+  }
+}
+

--- a/packages/infra/README.md
+++ b/packages/infra/README.md
@@ -1,0 +1,11 @@
+# Infra (AWS CDK)
+
+This package will host the AWS CDK stacks.
+
+- Scripts are placeholders for now.
+- Add `aws-cdk-lib` and constructs later.
+
+```bash
+pnpm --filter @collect-iq/infra synth
+```
+

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@collect-iq/infra",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "synth": "echo 'TODO: cdk synth'",
+    "deploy": "echo 'TODO: cdk deploy'"
+  }
+}
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,13 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}
+
+  apps/web: {}
+
+  packages/infra: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - "apps/*"
+  - "packages/*"
+


### PR DESCRIPTION
Initialize project structure with package.json, README.md, and .gitignore files for web and infra apps

Addresses #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established a monorepo structure with workspaces for apps and packages.
  * Added root configuration and workspace manifest.
  * Introduced initial web app and infrastructure package manifests with placeholder scripts (dev/build/start, synth/deploy).
  * Implemented a comprehensive ignore list to exclude builds, caches, environment files, and tooling artifacts from version control.
* **Documentation**
  * Added starter READMEs for the web app and infrastructure packages with brief descriptions and usage notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->