### PR TITLE
Add .env.example for environment variable configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,79 @@
+# CollectIQ Environment Variables
+#
+# Copy this file to `.env` for backend/local tooling and to `.env.local`
+# for the Next.js app (when present). Fill in values appropriate to your
+# AWS account and stack. Values prefixed with NEXT_PUBLIC_ are exposed to
+# the browser and must be safe to share client-side.
+#
+# Notes:
+# - Required vars are marked [required].
+# - Example values are suggestions; adjust for your environment.
+# - Defaults are provided where applicable.
+
+##############################
+# AWS Core (Region/Resources)
+##############################
+
+# [required] AWS region used by all services (e.g., us-east-1, us-west-2)
+AWS_REGION=us-east-1
+
+# [required] DynamoDB table name for card/vault records
+# Example: collectiq-cards-dev
+DDB_TABLE=
+
+# [required] S3 bucket name for direct uploads from the client
+# Example: collectiq-uploads-dev
+BUCKET_UPLOADS=
+
+##############################
+# Cognito (Server-side)
+##############################
+
+# [required] Cognito User Pool ID used for JWT validation (server-side)
+# Format: <region>_<alphanumeric>
+COGNITO_USER_POOL_ID=
+
+# [required] Cognito App Client ID for the User Pool (server-side usage)
+COGNITO_CLIENT_ID=
+
+############################################
+# Cognito + Region (Client-side / Next.js)
+############################################
+
+# [required] Region for client SDKs (mirrors AWS_REGION)
+NEXT_PUBLIC_REGION=us-east-1
+
+# [required] Cognito User Pool ID for client auth flows
+NEXT_PUBLIC_USER_POOL_ID=
+
+# [required] Cognito App Client ID used by the web app
+NEXT_PUBLIC_USER_POOL_CLIENT_ID=
+
+# [required] Cognito Identity Pool ID for federated identities (if used)
+# Format: <region>:<uuid>
+NEXT_PUBLIC_IDENTITY_POOL_ID=
+
+##############################
+# AI Models / Bedrock
+##############################
+
+# [required] Bedrock model identifier for identification/valuation logic
+# Examples:
+# - anthropic.claude-3-haiku-20240307-v1:0
+# - anthropic.claude-3-5-sonnet-20240620-v1:0
+# - amazon.titan-image-generator-v1
+BEDROCK_MODEL_ID=
+
+##############################
+# App Behavior / Defaults
+##############################
+
+# [optional] Rolling window (in days) for price aggregation
+# Default set per execution plan
+PRICE_WINDOW_DAYS=14
+
+# [optional] Use mock adapters for dev/demo flows
+# true  -> use mocked AI/market data
+# false -> use live integrations
+USE_MOCKS=true
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # collect-iq
+
+## Environment Setup
+
+Copy the example file and fill in values for your AWS account:
+
+```bash
+cp .env.example .env
+# If/when the Next.js web app is added, also copy for the app:
+cp .env.example apps/web/.env.local
+```
+
+See `.env.example` for all required variables and guidance.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Environment Setup instructions, including how to copy the example environment file to .env (and to apps/web/.env.local for Next.js). Clarifies required vs. optional variables and client-visible NEXT_PUBLIC-prefixed variables. References .env.example for details.
* **Chores**
  * Introduced .env.example template listing environment variables for AWS, Cognito (server/client), client config, AI models, and app defaults. Includes example values, defaults, and notes on required fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->